### PR TITLE
chore: remove @types/get-stdin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -677,15 +677,6 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
-    "@types/get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-kiDwIsKQvsLRvtBOnasij+6eChbCzcUT7OyVvrC5BEOE4QSKbpnwejEp0xND/9sIdOTfiu+BBl3zsB16MJ3Fww==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "homepage": "https://github.com/ninoseki/ioc-extractor",
   "devDependencies": {
-    "@types/get-stdin": "^7.0.0",
     "@types/jest": "^24.0.15",
     "@types/node": "^12.0.10",
     "@typescript-eslint/eslint-plugin": "^1.11.0",


### PR DESCRIPTION
Remove @types/get-stdin because get-stdin has its own type definition