### PR TITLE
🔧 Support `[://]` refanging

### DIFF
--- a/spec/auxiliary.spec.ts
+++ b/spec/auxiliary.spec.ts
@@ -69,6 +69,11 @@ describe("refang", () => {
     expect(refang(input)).toBe("http://example.com");
   });
 
+  it("should replace [://] by ://", () => {
+    const input = "http[://]example.com";
+    expect(refang(input)).toBe("http://example.com");
+  });
+
   it("should replace . by .", () => {
     const input = "http://example.com";
     expect(refang(input)).toBe("http://example.com");

--- a/src/aux/auxiliary.ts
+++ b/src/aux/auxiliary.ts
@@ -44,6 +44,7 @@ export function refang(s: string): string {
   ]);
   const colon = /\[:\]/gi;
   const slash = /\[\/\]/gi;
+  const colonSlash = /\[:\/\/\]/gi;
   const at = /(\[|\(|\{)(at|@)(\]|\)|\})/gi;
   const http = /h(xx|\*\*)p(s?):\/\//gi;
 
@@ -51,6 +52,7 @@ export function refang(s: string): string {
     .replace(dot, ".")
     .replace(colon, ":")
     .replace(slash, "/")
+    .replace(colonSlash, "://")
     .replace(http, "http$2://")
     .replace(at, "@");
 }


### PR DESCRIPTION
This is a small PR that adds support and tests for `[://]`. I've noticed Cisco Talos using this method https://blog.talosintelligence.com/2022/05/bitter-apt-adds-bangladesh-to-their.html
```
http[://]autodefragapp[.]com/
hxxp[://]olmajhnservice[.]com/updateReqServ10893x[.]php?x=035347
hxxp[://]olmajhnservice[.]com/
hxxps[://]olmajhnservice[.]com/nt[.]php/?dt=%25computername%25-BKP&ct=BKP
```